### PR TITLE
Support function rte_pmd_bnxt_set_all_queues_drop_en

### DIFF
--- a/app/test-pmd/cmdline.c
+++ b/app/test-pmd/cmdline.c
@@ -91,6 +91,9 @@
 #ifdef RTE_LIBRTE_IXGBE_PMD
 #include <rte_pmd_ixgbe.h>
 #endif
+#ifdef RTE_LIBRTE_BNXT_PMD
+#include <rte_pmd_bnxt.h>
+#endif
 #include "testpmd.h"
 
 static struct cmdline *testpmd_cl;
@@ -11289,8 +11292,12 @@ cmd_set_all_queues_drop_en_parsed(
 	struct cmd_all_queues_drop_en_result *res = parsed_result;
 	int ret = 0;
 	int is_on = (strcmp(res->on_off, "on") == 0) ? 1 : 0;
+	struct rte_eth_dev *dev = &rte_eth_devices[res->port_id];
 
-	ret = rte_pmd_ixgbe_set_all_queues_drop_en(res->port_id, is_on);
+	if (strcmp(dev->driver->pci_drv.driver.name, "net_bnxt") == 0)
+		ret = rte_pmd_bnxt_set_all_queues_drop_en(res->port_id, is_on);
+	else
+		ret = rte_pmd_ixgbe_set_all_queues_drop_en(res->port_id, is_on);
 	switch (ret) {
 	case 0:
 		break;

--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -58,6 +58,7 @@ struct bnxt_pf_info {
 #define BNXT_FIRST_PF_FID	1
 #define BNXT_MAX_VFS(bp)	(bp->pf.max_vfs)
 #define BNXT_FIRST_VF_FID	128
+#define BNXT_MAX_VF_NUM	128
 #define BNXT_PF_RINGS_USED(bp)	bnxt_get_num_queues(bp)
 #define BNXT_PF_RINGS_AVAIL(bp)	(bp->pf.max_cp_rings - BNXT_PF_RINGS_USED(bp))
 
@@ -68,6 +69,8 @@ struct bnxt_pf_info {
 	void			*vf_req_buf;
 	phys_addr_t		vf_req_buf_dma_addr;
 	uint32_t		vf_req_fwd[8];
+	uint16_t		vf_start_vnic[BNXT_MAX_VF_NUM];
+	uint16_t		vf_max_vnics[BNXT_MAX_VF_NUM];
 };
 
 /* Max wait time is 10 * 100ms = 1s */

--- a/drivers/net/bnxt/bnxt.h
+++ b/drivers/net/bnxt/bnxt.h
@@ -58,7 +58,7 @@ struct bnxt_pf_info {
 #define BNXT_FIRST_PF_FID	1
 #define BNXT_MAX_VFS(bp)	(bp->pf.max_vfs)
 #define BNXT_FIRST_VF_FID	128
-#define BNXT_MAX_VF_NUM	128
+#define BNXT_MAX_VF_NUM		128
 #define BNXT_PF_RINGS_USED(bp)	bnxt_get_num_queues(bp)
 #define BNXT_PF_RINGS_AVAIL(bp)	(bp->pf.max_cp_rings - BNXT_PF_RINGS_USED(bp))
 
@@ -69,8 +69,6 @@ struct bnxt_pf_info {
 	void			*vf_req_buf;
 	phys_addr_t		vf_req_buf_dma_addr;
 	uint32_t		vf_req_fwd[8];
-	uint16_t		vf_start_vnic[BNXT_MAX_VF_NUM];
-	uint16_t		vf_max_vnics[BNXT_MAX_VF_NUM];
 };
 
 /* Max wait time is 10 * 100ms = 1s */

--- a/drivers/net/bnxt/bnxt_cpr.h
+++ b/drivers/net/bnxt/bnxt_cpr.h
@@ -79,6 +79,7 @@ struct bnxt_cp_ring_info {
 
 
 struct bnxt;
+int bnxt_alloc_def_cp_ring(struct bnxt *bp);
 void bnxt_free_def_cp_ring(struct bnxt *bp);
 int bnxt_init_def_ring_struct(struct bnxt *bp, unsigned int socket_id);
 void bnxt_handle_async_event(struct bnxt *bp, struct cmpl_base *cmp);

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -448,34 +448,17 @@ static int bnxt_dev_start_op(struct rte_eth_dev *eth_dev)
 
 	bp->dev_stopped = 0;
 
-	rc = bnxt_setup_int(bp);
-	if (rc)
-		goto error;
-
-	rc = bnxt_alloc_mem(bp);
-	if (rc)
-		goto error;
-
-	rc = bnxt_request_int(bp);
-	if (rc)
-		goto error;
-
 	rc = bnxt_init_nic(bp);
 	if (rc)
 		goto error;
-
-	bnxt_enable_int(bp);
 
 	bnxt_link_update_op(eth_dev, 0);
 	return 0;
 
 error:
 	bnxt_shutdown_nic(bp);
-	bnxt_disable_int(bp);
-	bnxt_free_int(bp);
 	bnxt_free_tx_mbufs(bp);
 	bnxt_free_rx_mbufs(bp);
-	bnxt_free_mem(bp);
 	return rc;
 }
 
@@ -507,8 +490,6 @@ static void bnxt_dev_stop_op(struct rte_eth_dev *eth_dev)
 		eth_dev->data->dev_link.link_status = 0;
 	}
 	bnxt_set_hwrm_link_config(bp, false);
-	bnxt_disable_int(bp);
-	bnxt_free_int(bp);
 	bnxt_shutdown_nic(bp);
 	bp->dev_stopped = 1;
 }
@@ -1033,6 +1014,7 @@ init_err_disable:
 	return rc;
 }
 
+#define ALLOW_FUNC(x)	bp->pf.vf_req_fwd[((x)>>5)] &= ~rte_cpu_to_le_32((1<<((x) & 0x1f)))
 static int
 bnxt_dev_init(struct rte_eth_dev *eth_dev)
 {
@@ -1108,8 +1090,30 @@ bnxt_dev_init(struct rte_eth_dev *eth_dev)
 		goto error_free;
 	}
 
-	rc = bnxt_hwrm_func_driver_register(bp, 0,
-					    bp->pf.vf_req_fwd);
+	/* Forward all requests */
+	memset(bp->pf.vf_req_fwd, 0xff, sizeof(bp->pf.vf_req_fwd));
+	/*
+	 * We can't forward commands before the VF driver calls drv_rgtr.
+	 * These are the ones that are may be used by drivers.
+	 */
+	ALLOW_FUNC(HWRM_VER_GET);
+	ALLOW_FUNC(HWRM_QUEUE_QPORTCFG);
+	ALLOW_FUNC(HWRM_FUNC_QCFG);
+	ALLOW_FUNC(HWRM_FUNC_QCAPS);
+	ALLOW_FUNC(HWRM_FUNC_DRV_RGTR);
+
+	/*
+	 * The following are used for driver cleanup.  If we disallow these,
+	 * VF drivers can't clean up cleanly.
+	 */
+	ALLOW_FUNC(HWRM_FUNC_DRV_UNRGTR);
+	ALLOW_FUNC(HWRM_VNIC_FREE);
+	ALLOW_FUNC(HWRM_RING_FREE);
+	ALLOW_FUNC(HWRM_RING_GRP_FREE);
+	ALLOW_FUNC(HWRM_VNIC_RSS_COS_LB_CTX_FREE);
+	ALLOW_FUNC(HWRM_CFA_L2_FILTER_FREE);
+	ALLOW_FUNC(HWRM_STAT_CTX_FREE);
+	rc = bnxt_hwrm_func_driver_register(bp);
 	if (rc) {
 		RTE_LOG(ERR, PMD,
 			"Failed to register driver");
@@ -1149,8 +1153,32 @@ bnxt_dev_init(struct rte_eth_dev *eth_dev)
 		}
 	}
 
+	rc = bnxt_setup_int(bp);
+	if (rc)
+		goto error_free;
+
+	rc = bnxt_alloc_mem(bp);
+	if (rc)
+		goto error_free_int;
+
+	rc = bnxt_request_int(bp);
+	if (rc)
+		goto error_free_int;
+
+	rc = bnxt_alloc_def_cp_ring(bp);
+	if (rc)
+		goto error_free_int;
+
+	bnxt_enable_int(bp);
+
 	return 0;
 
+error_free_int:
+	bnxt_disable_int(bp);
+	bnxt_free_def_cp_ring(bp);
+	bnxt_hwrm_func_buf_unrgtr(bp);
+	bnxt_free_int(bp);
+	bnxt_free_mem(bp);
 error_free:
 	eth_dev->driver->eth_dev_uninit(eth_dev);
 error:
@@ -1162,6 +1190,9 @@ bnxt_dev_uninit(struct rte_eth_dev *eth_dev) {
 	struct bnxt *bp = eth_dev->data->dev_private;
 	int rc;
 
+	bnxt_disable_int(bp);
+	bnxt_free_int(bp);
+	bnxt_free_mem(bp);
 	if (eth_dev->data->mac_addrs != NULL) {
 		rte_free(eth_dev->data->mac_addrs);
 		eth_dev->data->mac_addrs = NULL;

--- a/drivers/net/bnxt/bnxt_ethdev.c
+++ b/drivers/net/bnxt/bnxt_ethdev.c
@@ -263,16 +263,6 @@ static int bnxt_init_chip(struct bnxt *bp)
 		}
 	}
 
-	if (BNXT_PF(bp) && bp->pf.active_vfs > 0) {
-		/* Update each VF's start vnic id */
-		uint16_t fw_vnic_id = bp->vnic_info[0].fw_vnic_id + bp->max_vnics;
-		int j;
-		for (j = bp->pf.active_vfs - 1; j >= 0; j--) {
-			bp->pf.vf_start_vnic[j] = fw_vnic_id;
-			fw_vnic_id += bp->pf.vf_max_vnics[j];
-		}
-	}
-
 	return 0;
 
 err_out:
@@ -831,14 +821,12 @@ int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on)
 	return 0;
 }
 
-
 int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 {
-	struct rte_eth_dev 		*eth_dev;
-	struct bnxt 			*bp;
-	struct bnxt_vnic_info	*vnic;
-	int						 i;
-	int						 rc;
+	struct rte_eth_dev *eth_dev;
+	struct bnxt *bp;
+	uint32_t i;
+	int rc;
 
 	RTE_ETH_VALID_PORTID_OR_ERR_RET(port, -ENODEV);
 
@@ -856,20 +844,22 @@ int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on)
 	if (bp->vnic_info == NULL)
 		return -ENODEV;
 
-	vnic = &bp->vnic_info[0];
-	if (on)
-		vnic->flags &= ~BNXT_VNIC_INFO_UNICAST;
-	else
-		vnic->flags |= BNXT_VNIC_INFO_UNICAST;
-
 	/* Stall PF */
-	rc = bnxt_hwrm_vnic_stall(bp, vnic->fw_vnic_id, on);
+	for (i = 0; i < bp->nr_vnics; i++) {
+		bp->vnic_info[i].bd_stall = on;
+		rc = bnxt_hwrm_vnic_cfg(bp, &bp->vnic_info[i]);
+		if (rc) {
+			RTE_LOG(ERR, PMD, "Failed to update PF VNIC %d.\n", i);
+			return rc;
+		}
+	}
 
 	/* Stall all active VFs */
 	for (i = 0; i < bp->pf.active_vfs; i++) {
 		rc = bnxt_hwrm_func_vf_stall(bp, i, on);
 		if (rc) {
-			RTE_LOG(ERR, PMD, "Failed to update VNIC %d state to: %s.\n", i, on ? "on":"off");
+			RTE_LOG(ERR, PMD, "Failed to update VF VNIC %d.\n", i);
+			break;
 		}
 	}
 

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -52,6 +52,31 @@
 
 #define HWRM_CMD_TIMEOUT		2000
 
+static int page_getenum(size_t size)
+{
+	if (size <= 1<<4)
+		return 4;
+	if (size <= 1<<12)
+		return 12;
+	if (size <= 1<<13)
+		return 13;
+	if (size <= 1<<16)
+		return 16;
+	if (size <= 1<<21)
+		return 21;
+	if (size <= 1<<22)
+		return 22;
+	if (size <= 1<<30)
+		return 30;
+	RTE_LOG(ERR, PMD, "Page size %zu out of range\n", size);
+	return sizeof(void *)*8-1;
+}
+
+static int page_roundup(size_t size)
+{
+	return 1<<page_getenum(size);
+}
+
 /*
  * HWRM Functions (sent to HWRM)
  * These are named bnxt_hwrm_*() and return -1 if bnxt_hwrm_send_message()
@@ -250,24 +275,6 @@ int bnxt_hwrm_set_filter(struct bnxt *bp,
 	return rc;
 }
 
-int bnxt_hwrm_exec_fwd_resp(struct bnxt *bp, void *fwd_cmd)
-{
-	int rc;
-	struct hwrm_exec_fwd_resp_input req = {.req_type = 0 };
-	struct hwrm_exec_fwd_resp_output *resp = bp->hwrm_cmd_resp_addr;
-
-	HWRM_PREP(req, EXEC_FWD_RESP, -1, resp);
-
-	memcpy(req.encap_request, fwd_cmd,
-	       sizeof(req.encap_request));
-
-	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
-
-	HWRM_CHECK_RESULT;
-
-	return rc;
-}
-
 int bnxt_hwrm_func_qcaps(struct bnxt *bp)
 {
 	int rc = 0;
@@ -319,8 +326,7 @@ int bnxt_hwrm_func_reset(struct bnxt *bp)
 	return rc;
 }
 
-int bnxt_hwrm_func_driver_register(struct bnxt *bp, uint32_t flags,
-				   uint32_t *vf_req_fwd)
+int bnxt_hwrm_func_driver_register(struct bnxt *bp)
 {
 	int rc;
 	struct hwrm_func_drv_rgtr_input req = {.req_type = 0 };
@@ -330,15 +336,16 @@ int bnxt_hwrm_func_driver_register(struct bnxt *bp, uint32_t flags,
 		return 0;
 
 	HWRM_PREP(req, FUNC_DRV_RGTR, -1, resp);
-	req.flags = flags;
-	req.enables = HWRM_FUNC_DRV_RGTR_INPUT_ENABLES_VER |
-			HWRM_FUNC_DRV_RGTR_INPUT_ENABLES_ASYNC_EVENT_FWD |
-			HWRM_FUNC_DRV_RGTR_INPUT_ENABLES_VF_INPUT_FWD;
+	req.enables = rte_cpu_to_le_32(HWRM_FUNC_DRV_RGTR_INPUT_ENABLES_VER |
+			HWRM_FUNC_DRV_RGTR_INPUT_ENABLES_ASYNC_EVENT_FWD);
 	req.ver_maj = RTE_VER_YEAR;
 	req.ver_min = RTE_VER_MONTH;
 	req.ver_upd = RTE_VER_MINOR;
 
-	memcpy(req.vf_req_fwd, vf_req_fwd, sizeof(req.vf_req_fwd));
+	if (BNXT_PF(bp)) {
+		req.enables |= rte_cpu_to_le_32(HWRM_FUNC_DRV_RGTR_INPUT_ENABLES_VF_INPUT_FWD);
+		memcpy(req.vf_req_fwd, bp->pf.vf_req_fwd, RTE_MIN(sizeof(req.vf_req_fwd), sizeof(bp->pf.vf_req_fwd)));
+	}
 
 	req.async_event_fwd[0] |= rte_cpu_to_le_32(0x1);   /* TODO: Use MACRO */
 
@@ -944,6 +951,83 @@ int bnxt_hwrm_vnic_rss_cfg(struct bnxt *bp,
 	return rc;
 }
 
+int bnxt_hwrm_func_buf_rgtr(struct bnxt *bp)
+{
+	int rc = 0;
+	struct hwrm_func_buf_rgtr_input req = {.req_type = 0 };
+	struct hwrm_func_buf_rgtr_output *resp = bp->hwrm_cmd_resp_addr;
+
+	HWRM_PREP(req, FUNC_BUF_RGTR, -1, resp);
+
+	req.req_buf_num_pages = rte_cpu_to_le_16(1);
+	req.req_buf_page_size = rte_cpu_to_le_16(page_getenum(bp->pf.active_vfs * HWRM_MAX_REQ_LEN));
+	req.req_buf_len = rte_cpu_to_le_16(HWRM_MAX_REQ_LEN);
+	req.req_buf_page_addr[0] = rte_cpu_to_le_64(bp->pf.vf_req_buf_dma_addr);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}
+
+int bnxt_hwrm_func_buf_unrgtr(struct bnxt *bp)
+{
+	int rc = 0;
+	struct hwrm_func_buf_unrgtr_input req = {.req_type = 0 };
+	struct hwrm_func_buf_unrgtr_output *resp = bp->hwrm_cmd_resp_addr;
+
+	HWRM_PREP(req, FUNC_BUF_UNRGTR, -1, resp);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}
+
+int bnxt_hwrm_reject_fwd_resp(struct bnxt *bp, uint16_t target_id, void *encaped, size_t ec_size)
+{
+	int rc = 0;
+	struct hwrm_reject_fwd_resp_input req = {.req_type = 0};
+	struct hwrm_reject_fwd_resp_output *resp = bp->hwrm_cmd_resp_addr;
+
+	if (ec_size > sizeof(req.encap_request))
+		return -1;
+
+	HWRM_PREP(req, REJECT_FWD_RESP, -1, resp);
+
+	req.encap_resp_target_id = rte_cpu_to_le_16(target_id);
+	memcpy(req.encap_request, encaped, ec_size);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}
+
+int bnxt_hwrm_exec_fwd_resp(struct bnxt *bp, uint16_t target_id, void *encaped, size_t ec_size)
+{
+	int rc = 0;
+	struct hwrm_exec_fwd_resp_input req = {.req_type = 0};
+	struct hwrm_exec_fwd_resp_output *resp = bp->hwrm_cmd_resp_addr;
+
+	if (ec_size > sizeof(req.encap_request))
+		return -1;
+
+	HWRM_PREP(req, EXEC_FWD_RESP, -1, resp);
+
+	req.encap_resp_target_id = rte_cpu_to_le_16(target_id);
+	memcpy(req.encap_request, encaped, ec_size);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+
+	HWRM_CHECK_RESULT;
+
+	return rc;
+}
+
 /*
  * HWRM utility functions
  */
@@ -1205,7 +1289,8 @@ void bnxt_free_all_hwrm_resources(struct bnxt *bp)
 		return;
 
 	vnic = &bp->vnic_info[0];
-	bnxt_hwrm_cfa_l2_clear_rx_mask(bp, vnic);
+	if (BNXT_PF(bp))
+		bnxt_hwrm_cfa_l2_clear_rx_mask(bp, vnic);
 
 	/* VNIC resources */
 	for (i = 0; i < bp->nr_vnics; i++) {
@@ -1502,8 +1587,6 @@ int bnxt_hwrm_func_qcfg(struct bnxt *bp)
 
 	/* Hard Coded.. 0xfff VLAN ID mask */
 	bp->vlan = rte_le_to_cpu_16(resp->vlan) & 0xfff;
-	if (BNXT_PF(bp))
-		bp->pf.active_vfs = rte_le_to_cpu_16(resp->alloc_vfs);
 
 	switch (resp->port_partition_type) {
 	case HWRM_FUNC_QCFG_OUTPUT_PORT_PARTITION_TYPE_NPAR1_0:
@@ -1677,8 +1760,8 @@ static int update_pf_resource_max(struct bnxt *bp)
 	HWRM_CHECK_RESULT;
 
 	bp->max_tx_rings = rte_le_to_cpu_16(resp->alloc_tx_rings);
-	bp->pf.active_vfs = rte_le_to_cpu_16(resp->alloc_vfs);
 	/* TODO: Only TX ring value reflects actual allocation */
+	//bp->pf.active_vfs = rte_le_to_cpu_16(resp->alloc_vfs);
 	//bp->max_rx_rings = rte_le_to_cpu_16(resp->alloc_rx_rings);
 	//bp->max_cp_rings = rte_le_to_cpu_16(resp->alloc_cmpl_rings);
 	//bp->max_rsscos_ctx = rte_le_to_cpu_16(resp->alloc_rsscos_ctx);
@@ -1722,7 +1805,7 @@ int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs)
 	if (rc)
 		return rc;
 
-	bp->pf.active_vfs = 0;
+	bp->pf.active_vfs = num_vfs;
 
 	/*
 	 * First, configure the PF to only use one TX ring.  This ensures that
@@ -1738,8 +1821,24 @@ int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs)
 	if (rc)
 		return rc;
 
+	/*
+	 * Now, create and register a buffer to hold forwarded VF requests
+	 */
+	bp->pf.vf_req_buf = rte_malloc("bnxt_vf_fwd", num_vfs * HWRM_MAX_REQ_LEN, 
+		page_roundup(num_vfs * HWRM_MAX_REQ_LEN));
+	if (bp->pf.vf_req_buf == NULL) {
+		rc = -ENOMEM;
+		goto error_free;
+	}
+	bp->pf.vf_req_buf_dma_addr = rte_malloc_virt2phy(bp->pf.vf_req_buf);
+
+	rc = bnxt_hwrm_func_buf_rgtr(bp);
+	if (rc)
+		goto error_free;
+
 	populate_vf_func_cfg_req(bp, &req, num_vfs);
 
+	bp->pf.active_vfs = 0;
 	for (i = 0; i < num_vfs; i++) {
 		add_random_mac_if_needed(bp, &req, i);
 
@@ -1756,6 +1855,7 @@ int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs)
 		}
 
 		reserve_resources_from_vf(bp, &req, i);
+		bp->pf.active_vfs++;
 	}
 
 	/*
@@ -1766,9 +1866,15 @@ int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs)
 	 */
 	rc = bnxt_hwrm_alloc_pf_rx_rings(bp, bp->max_tx_rings, true);
 	if (rc)
-		return rc;
+		goto error_free;
 
 	rc = update_pf_resource_max(bp);
+	if (rc)
+		goto error_free;
 
+	return rc;
+
+error_free:
+	bnxt_hwrm_func_buf_unrgtr(bp);
 	return rc;
 }

--- a/drivers/net/bnxt/bnxt_hwrm.c
+++ b/drivers/net/bnxt/bnxt_hwrm.c
@@ -154,7 +154,7 @@ static int bnxt_hwrm_send_message(struct bnxt *bp, void *msg, uint32_t msg_len)
 	req.target_id = rte_cpu_to_le_16(0xffff); \
 	req.resp_addr = rte_cpu_to_le_64(bp->hwrm_cmd_resp_dma_addr)
 
-#define HWRM_CHECK_RESPONSE(resp) \
+#define HWRM_CHECK_RESULT \
 	{ \
 		if (rc) { \
 			RTE_LOG(ERR, PMD, "%s failed rc:%d\n", \
@@ -167,8 +167,6 @@ static int bnxt_hwrm_send_message(struct bnxt *bp, void *msg, uint32_t msg_len)
 			return rc; \
 		} \
 	}
-
-#define HWRM_CHECK_RESULT HWRM_CHECK_RESPONSE(resp)
 
 int bnxt_hwrm_cfa_l2_clear_rx_mask(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 {
@@ -845,8 +843,9 @@ int bnxt_hwrm_vnic_cfg(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 	HWRM_PREP(req, VNIC_CFG, -1, resp);
 
 	/* Only RSS support for now TBD: COS & LB */
-	req.enables =
-	    rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_ENABLES_DFLT_RING_GRP |
+	if (!vnic->bd_stall)
+		req.enables =
+			rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_ENABLES_DFLT_RING_GRP |
 			     HWRM_VNIC_CFG_INPUT_ENABLES_RSS_RULE |
 			     HWRM_VNIC_CFG_INPUT_ENABLES_MRU);
 	req.vnic_id = rte_cpu_to_le_16(vnic->fw_vnic_id);
@@ -862,6 +861,9 @@ int bnxt_hwrm_vnic_cfg(struct bnxt *bp, struct bnxt_vnic_info *vnic)
 	if (vnic->vlan_strip)
 		req.flags |=
 		    rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_VLAN_STRIP_MODE);
+	if (vnic->bd_stall)
+		req.flags |=
+			rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_BD_STALL_MODE);
 
 	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
 
@@ -953,57 +955,50 @@ int bnxt_hwrm_vnic_rss_cfg(struct bnxt *bp,
 	return rc;
 }
 
-int bnxt_hwrm_vnic_stall(struct bnxt *bp, uint16_t fw_vnic_id, uint8_t on)
-{
-	struct hwrm_vnic_cfg_input req = {0};
-	struct hwrm_vnic_cfg_output *resp = bp->hwrm_cmd_resp_addr;
-	int rc = 0;
+#define HW_MAX_VNICS 170
 
-	HWRM_PREP(req, VNIC_CFG, -1, resp);
-
-	if (on)
-		req.flags |= rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_BD_STALL_MODE);
-	req.vnic_id = rte_cpu_to_le_16(fw_vnic_id);
-
-	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
-
-	HWRM_CHECK_RESULT;
-
-	return rc;
-}
-
-/*
- * func_vf_vnic_ids_query
- * 	vnic_qcfg
- * 	HWRM_VNIC_CFG
- */
 int bnxt_hwrm_func_vf_stall(struct bnxt *bp, uint16_t vf, uint8_t on)
 {
-	struct hwrm_func_vf_vnic_ids_query_input req_vf_vnic_ids = {0};
-	struct hwrm_func_vf_vnic_ids_query_output *resp_vf_vnic_ids = bp->hwrm_cmd_resp_addr;
-	struct hwrm_vnic_cfg_input req_vnic_cfg = {0};
-	struct hwrm_vnic_cfg_output *resp_vnic_cfg = bp->hwrm_cmd_resp_addr;
-	int rc = 0;
-	uint32_t i, vnic_ids;
+	struct hwrm_func_vf_vnic_ids_query_input req = {0};
+	struct hwrm_func_vf_vnic_ids_query_output *resp = bp->hwrm_cmd_resp_addr;
+	struct bnxt_vnic_info vnic;
+	int rc;
+	uint32_t i, num_vnic_ids;
+	uint16_t *vnic_ids;
 
-	HWRM_PREP(req_vf_vnic_ids, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
-	req_vf_vnic_ids.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
-	rc = bnxt_hwrm_send_message(bp, &req_vf_vnic_ids, sizeof(req_vf_vnic_ids));
-	HWRM_CHECK_RESPONSE(resp_vf_vnic_ids);
+	/* First query all VNIC ids */
 
-	vnic_ids = resp_vf_vnic_ids->vnic_id_cnt;
-
-	HWRM_PREP(req_vnic_cfg, VNIC_CFG, -1, resp_vnic_cfg);
-	if (on)
-		req_vnic_cfg.flags |= rte_cpu_to_le_32(HWRM_VNIC_CFG_INPUT_FLAGS_BD_STALL_MODE);
-
-	for (i = 0; i < vnic_ids; i++) {
-		req_vnic_cfg.vnic_id = rte_cpu_to_le_16(bp->pf.vf_start_vnic[vf] + i);
-		rc = bnxt_hwrm_send_message(bp, &req_vnic_cfg, sizeof(req_vnic_cfg));
-		if (rc || resp_vnic_cfg->error_code) {
-			RTE_LOG(ERR, PMD, "Failed to stall VF %d vnic %d.\n", vf, i);
-		}
+	vnic_ids = rte_malloc("bnxt_hwrm_vf_vnic_ids_query", HW_MAX_VNICS * sizeof(*vnic_ids),
+			RTE_CACHE_LINE_SIZE);
+	if (vnic_ids == NULL) {
+		rc = -ENOMEM;
+		return rc;
 	}
+
+	HWRM_PREP(req, FUNC_VF_VNIC_IDS_QUERY, -1, resp_vf_vnic_ids);
+
+	req.vf_id = rte_cpu_to_le_16(bp->pf.first_vf_id + vf);
+	req.max_vnic_id_cnt = rte_cpu_to_le_32(HW_MAX_VNICS);
+	req.vnic_id_tbl_addr = rte_malloc_virt2phy(vnic_ids);
+
+	rc = bnxt_hwrm_send_message(bp, &req, sizeof(req));
+	HWRM_CHECK_RESULT;
+
+	num_vnic_ids = resp->vnic_id_cnt;
+
+	/* Retrieve VNIC, update bd_stall then update */
+
+	for (i = 0; i < num_vnic_ids; i++) {
+		memset(&vnic, 0, sizeof(struct bnxt_vnic_info));
+		vnic.fw_vnic_id = vnic_ids[i];
+		vnic.bd_stall = on;
+		//TODO bnxt_hwrm_vnic_qcfg(&vnic);
+		//rc = bnxt_hwrm_vnic_cfg(bp, &vnic);
+		if (rc)
+			break;
+	}
+
+	rte_free(vnic_ids);
 
 	return rc;
 }
@@ -1802,8 +1797,6 @@ static void reserve_resources_from_vf(struct bnxt *bp, struct hwrm_func_cfg_inpu
 	bp->max_l2_ctx -= rte_le_to_cpu_16(resp->max_l2_ctxs);
 	bp->max_vnics -= rte_le_to_cpu_16(resp->max_vnics);
 	bp->max_ring_grps -= rte_le_to_cpu_16(resp->max_hw_ring_grps);
-
-	bp->pf.vf_max_vnics[vf] = rte_le_to_cpu_16(resp->max_vnics);
 }
 
 static int update_pf_resource_max(struct bnxt *bp)

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -52,10 +52,14 @@ int bnxt_hwrm_set_filter(struct bnxt *bp,
 			 struct bnxt_vnic_info *vnic,
 			 struct bnxt_filter_info *filter);
 
-int bnxt_hwrm_exec_fwd_resp(struct bnxt *bp, void *fwd_cmd);
+int bnxt_hwrm_exec_fwd_resp(struct bnxt *bp, uint16_t target_id,
+			    void *encaped, size_t ec_size);
+int bnxt_hwrm_reject_fwd_resp(struct bnxt *bp, uint16_t target_id,
+			      void *encaped, size_t ec_size);
 
-int bnxt_hwrm_func_driver_register(struct bnxt *bp, uint32_t flags,
-				   uint32_t *vf_req_fwd);
+int bnxt_hwrm_func_buf_rgtr(struct bnxt *bp);
+int bnxt_hwrm_func_buf_unrgtr(struct bnxt *bp);
+int bnxt_hwrm_func_driver_register(struct bnxt *bp);
 int bnxt_hwrm_func_qcaps(struct bnxt *bp);
 int bnxt_hwrm_func_reset(struct bnxt *bp);
 int bnxt_hwrm_func_driver_unregister(struct bnxt *bp, uint32_t flags);

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -90,6 +90,8 @@ int bnxt_hwrm_vnic_ctx_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_rss_cfg(struct bnxt *bp,
 			   struct bnxt_vnic_info *vnic);
+int bnxt_hwrm_vnic_stall(struct bnxt *bp, uint16_t fw_vnic_id,
+			   uint8_t on);
 
 int bnxt_alloc_all_hwrm_stat_ctxs(struct bnxt *bp);
 int bnxt_clear_all_hwrm_stat_ctxs(struct bnxt *bp);
@@ -107,5 +109,6 @@ int bnxt_set_hwrm_link_config(struct bnxt *bp, bool link_up);
 int bnxt_hwrm_func_qcfg(struct bnxt *bp);
 int bnxt_hwrm_allocate_pf_only(struct bnxt *bp);
 int bnxt_hwrm_allocate_vfs(struct bnxt *bp, int num_vfs);
+int bnxt_hwrm_func_vf_stall(struct bnxt *bp, uint16_t vf, uint8_t on);
 
 #endif

--- a/drivers/net/bnxt/bnxt_hwrm.h
+++ b/drivers/net/bnxt/bnxt_hwrm.h
@@ -90,7 +90,7 @@ int bnxt_hwrm_vnic_ctx_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_free(struct bnxt *bp, struct bnxt_vnic_info *vnic);
 int bnxt_hwrm_vnic_rss_cfg(struct bnxt *bp,
 			   struct bnxt_vnic_info *vnic);
-int bnxt_hwrm_vnic_stall(struct bnxt *bp, uint16_t fw_vnic_id,
+int bnxt_hwrm_vnic_stall(struct bnxt *bp, struct bnxt_vnic_info *vnic,
 			   uint8_t on);
 
 int bnxt_alloc_all_hwrm_stat_ctxs(struct bnxt *bp);

--- a/drivers/net/bnxt/bnxt_irq.c
+++ b/drivers/net/bnxt/bnxt_irq.c
@@ -67,11 +67,11 @@ static void bnxt_int_handler(struct rte_intr_handle *handle __rte_unused,
 			/* Handle any async event */
 			bnxt_handle_async_event(bp, cmp);
 			break;
-		case CMPL_BASE_TYPE_HWRM_FWD_RESP:
-			/* Handle HWRM forwarded responses */
+		case CMPL_BASE_TYPE_HWRM_FWD_REQ:
 			bnxt_handle_fwd_req(bp, cmp);
 			break;
 		default:
+			RTE_LOG(INFO, PMD, "Ignoring %02x completion\n", CMP_TYPE(cmp));
 			/* Ignore any other events */
 			break;
 		}

--- a/drivers/net/bnxt/bnxt_ring.c
+++ b/drivers/net/bnxt/bnxt_ring.c
@@ -213,21 +213,6 @@ int bnxt_alloc_hwrm_rings(struct bnxt *bp)
 	unsigned int i;
 	int rc = 0;
 
-	/* Default completion ring */
-	{
-		struct bnxt_cp_ring_info *cpr = bp->def_cp_ring;
-		struct bnxt_ring *cp_ring = cpr->cp_ring_struct;
-
-		rc = bnxt_hwrm_ring_alloc(bp, cp_ring,
-					  HWRM_RING_ALLOC_INPUT_RING_TYPE_CMPL,
-					  0, HWRM_NA_SIGNATURE);
-		if (rc)
-			goto err_out;
-		cpr->cp_doorbell = pci_dev->mem_resource[2].addr;
-		B_CP_DIS_DB(cpr, cpr->cp_raw_cons);
-		bp->grp_info[0].cp_fw_ring_id = cp_ring->fw_ring_id;
-	}
-
 	for (i = 0; i < bp->rx_cp_nr_rings; i++) {
 		struct bnxt_rx_queue *rxq = bp->rx_queues[i];
 		struct bnxt_cp_ring_info *cpr = rxq->cp_ring;

--- a/drivers/net/bnxt/bnxt_vnic.h
+++ b/drivers/net/bnxt/bnxt_vnic.h
@@ -59,6 +59,7 @@ struct bnxt_vnic_info {
 	uint32_t	flags;
 #define BNXT_VNIC_INFO_PROMISC			(1 << 0)
 #define BNXT_VNIC_INFO_ALLMULTI			(1 << 1)
+#define BNXT_VNIC_INFO_UNICAST			(1 << 2)
 
 	bool		vlan_strip;
 	bool		func_default;

--- a/drivers/net/bnxt/bnxt_vnic.h
+++ b/drivers/net/bnxt/bnxt_vnic.h
@@ -59,10 +59,10 @@ struct bnxt_vnic_info {
 	uint32_t	flags;
 #define BNXT_VNIC_INFO_PROMISC			(1 << 0)
 #define BNXT_VNIC_INFO_ALLMULTI			(1 << 1)
-#define BNXT_VNIC_INFO_UNICAST			(1 << 2)
 
 	bool		vlan_strip;
 	bool		func_default;
+	bool		bd_stall;
 
 	STAILQ_HEAD(, bnxt_filter_info)	filter;
 };

--- a/drivers/net/bnxt/hsi_struct_def_dpdk.h
+++ b/drivers/net/bnxt/hsi_struct_def_dpdk.h
@@ -74,23 +74,25 @@ struct ctx_hw_stats64 {
  * Following is the signature for HWRM message field that indicates not
  * applicable (All F's). Need to cast it the size of the field if needed.
  */
-#define HWRM_NA_SIGNATURE        ((uint32_t)(-1))
-#define HWRM_MAX_REQ_LEN	(128)  /* hwrm_func_buf_rgtr */
-#define HWRM_MAX_RESP_LEN	(176)  /* hwrm_func_qstats */
-#define HW_HASH_INDEX_SIZE      0x80    /* 7 bit indirection table index. */
-#define HW_HASH_KEY_SIZE        40
-#define HWRM_RESP_VALID_KEY	1 /* valid key for HWRM response */
+#define HWRM_NA_SIGNATURE	((uint32_t)(-1))
+#define HWRM_MAX_REQ_LEN	128	/* hwrm_func_buf_rgtr */
+#define HWRM_MAX_RESP_LEN	176	/* hwrm_func_qstats */
+#define HW_HASH_INDEX_SIZE	0x80	/* 7 bit indirection table index. */
+#define HW_HASH_KEY_SIZE	40
+#define HWRM_RESP_VALID_KEY	1	/* valid key for HWRM response */
 
 /*
  * Request types
  */
 #define HWRM_VER_GET			(UINT32_C(0x0))
+#define HWRM_FUNC_BUF_UNRGTR		(UINT32_C(0xe))
 #define HWRM_FUNC_RESET			(UINT32_C(0x11))
 #define HWRM_FUNC_QCAPS			(UINT32_C(0x15))
 #define HWRM_FUNC_QCFG			(UINT32_C(0x16))
 #define HWRM_FUNC_CFG			(UINT32_C(0x17))
 #define HWRM_FUNC_DRV_UNRGTR		(UINT32_C(0x1a))
 #define HWRM_FUNC_DRV_RGTR		(UINT32_C(0x1d))
+#define HWRM_FUNC_BUF_RGTR		(UINT32_C(0x1f))
 #define HWRM_PORT_PHY_CFG		(UINT32_C(0x20))
 #define HWRM_PORT_PHY_QCFG		(UINT32_C(0x27))
 #define HWRM_QUEUE_QPORTCFG		(UINT32_C(0x30))
@@ -112,10 +114,11 @@ struct ctx_hw_stats64 {
 #define HWRM_STAT_CTX_FREE		(UINT32_C(0xb1))
 #define HWRM_STAT_CTX_CLR_STATS		(UINT32_C(0xb3))
 #define HWRM_EXEC_FWD_RESP		(UINT32_C(0xd0))
+#define HWRM_REJECT_FWD_RESP		(UINT32_C(0xd1))
 
 /* Return Codes */
-#define HWRM_ERR_CODE_INVALID_PARAMS                      (UINT32_C(0x2))
-#define HWRM_ERR_CODE_RESOURCE_ACCESS_DENIED              (UINT32_C(0x3))
+#define HWRM_ERR_CODE_INVALID_PARAMS		(UINT32_C(0x2))
+#define HWRM_ERR_CODE_RESOURCE_ACCESS_DENIED	(UINT32_C(0x3))
 
 /* Short TX BD (16 bytes) */
 struct tx_bd_short {
@@ -1613,6 +1616,84 @@ struct hwrm_ver_get_output {
 	 */
 } __attribute__((packed));
 
+/* hwrm_func_buf_unrgtr */
+/*
+ * Description: This command is used by the PF driver to unregister buffers used
+ * in the PF-VF communication with the HWRM. The PF driver uses this command to
+ * unregister buffers for PF-VF communication. A parent PF may issue this
+ * command to unregister buffers for communication between the PF and a specific
+ * VF. If the VF ID is not valid, then this command is used to unregister
+ * buffers used for communications with all children VFs of the PF.
+ */
+/* Input (24 bytes) */
+struct hwrm_func_buf_unrgtr_input {
+	uint16_t req_type;
+	/*
+	 * This value indicates what type of request this is. The format for the
+	 * rest of the command is determined by this field.
+	 */
+	uint16_t cmpl_ring;
+	/*
+	 * This value indicates the what completion ring the request will be
+	 * optionally completed on. If the value is -1, then no CR completion
+	 * will be generated. Any other value must be a valid CR ring_id value
+	 * for this function.
+	 */
+	uint16_t seq_id;
+	/* This value indicates the command sequence number. */
+	uint16_t target_id;
+	/*
+	 * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
+	 * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+	 */
+	uint64_t resp_addr;
+	/*
+	 * This is the host address where the response will be written when the
+	 * request is complete. This area must be 16B aligned and must be
+	 * cleared to zero before the request is made.
+	 */
+	uint32_t enables;
+	/* This bit must be '1' for the vf_id field to be configured. */
+	#define HWRM_FUNC_BUF_UNRGTR_INPUT_ENABLES_VF_ID           (UINT32_C(0x1))
+	uint16_t vf_id;
+	/*
+	 * This value is used to identify a Virtual Function (VF). The scope of
+	 * VF ID is local within a PF.
+	 */
+	uint16_t unused_0;
+} __attribute__((packed));
+
+/* Output (16 bytes) */
+struct hwrm_func_buf_unrgtr_output {
+	uint16_t error_code;
+	/*
+	 * Pass/Fail or error type Note: receiver to verify the in parameters,
+	 * and fail the call with an error when appropriate
+	 */
+	uint16_t req_type;
+	/* This field returns the type of original request. */
+	uint16_t seq_id;
+	/* This field provides original sequence number of the command. */
+	uint16_t resp_len;
+	/*
+	 * This field is the length of the response in bytes. The last byte of
+	 * the response is a valid flag that will read as '1' when the command
+	 * has been completely written to memory.
+	 */
+	uint32_t unused_0;
+	uint8_t unused_1;
+	uint8_t unused_2;
+	uint8_t unused_3;
+	uint8_t valid;
+	/*
+	 * This field is used in Output records to indicate that the output is
+	 * completely written to RAM. This field should be read as '1' to
+	 * indicate that the output has been completely written. When writing a
+	 * command completion or response to an internal processor, the order of
+	 * writes has to be such that this field is written last.
+	 */
+} __attribute__((packed));
+
 /* hwrm_func_reset */
 /*
  * Description: This command resets a hardware function (PCIe function) and
@@ -2299,348 +2380,349 @@ struct hwrm_func_qcfg_output {
  */
 /* Input (88 bytes) */
 struct hwrm_func_cfg_input {
-    uint16_t req_type;
-    /*
-     * This value indicates what type of request this is. The format for the
-     * rest of the command is determined by this field.
-     */
-    uint16_t cmpl_ring;
-    /*
-     * This value indicates the what completion ring the request will be
-     * optionally completed on. If the value is -1, then no CR completion
-     * will be generated. Any other value must be a valid CR ring_id value
-     * for this function.
-     */
-    uint16_t seq_id;
-    /* This value indicates the command sequence number. */
-    uint16_t target_id;
-    /*
-     * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
-     * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
-     */
-    uint64_t resp_addr;
-    /*
-     * This is the host address where the response will be written when the
-     * request is complete. This area must be 16B aligned and must be
-     * cleared to zero before the request is made.
-     */
-    uint16_t fid;
-    /*
-     * Function ID of the function that is being configured. If set to
-     * 0xFF... (All Fs), then the the configuration is for the requesting
-     * function.
-     */
-    uint8_t unused_0;
-    uint8_t unused_1;
-    uint32_t flags;
-    /*
-     * When this bit is '1', the function is requested to be put in the
-     * promiscuous mode.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_PROM_MODE                (UINT32_C(0x1))
-    /*
-     * When this bit is '1', the function is enabled with source MAC address
-     * check. This is an anti-spoofing check. If this flag is set, then the
-     * function shall be configured to allow transmission of frames with the
-     * source MAC address that is configured for this function.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_SRC_MAC_ADDR_CHECK       (UINT32_C(0x2))
-    /*
-     * When this bit is '1', the function is enabled with source IP address
-     * check. This is an anti-spoofing check. If this flag is set, then the
-     * function shall be configured to allow transmission of frames with the
-     * source IP address that is configured for this function.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_SRC_IP_ADDR_CHECK        (UINT32_C(0x4))
-    /*
-     * When this bit is set to '1', the function shall be configured with
-     * VLAN priority match. If the VLAN PRI of a packet originated from this
-     * function does not match, then the packet shall be discarded.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_VLAN_PRI_MATCH           (UINT32_C(0x8))
-    /*
-     * When this bit is set to '1', the function shall be configured to
-     * check for VLAN priority match. If the VLAN PRI of a packet originated
-     * from this function does not match, then the default VLAN PRI shall be
-     * used.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_DFLT_PRI_NOMATCH         (UINT32_C(0x10))
-    /*
-     * When this bit is set to '1', the function shall be configured to not
-     * allow the transmission of pause frames. PAUSE frames use 48-bit
-     * destination multicast MAC address 01-80-C2-00-00-01.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_PAUSE            (UINT32_C(0x20))
-    /*
-     * When this bit is set to '1', the function shall be configured to not
-     * allow the transmission of Spanning Tree Protocol (STP) frames. STP
-     * frames use Ethertype 0x0802 and 48-bit destination multicast MAC
-     * address 01-80-C2-00-00-00 and 01-80-C2-00-00-08 for 802.1D and
-     * 802.1ad respectively.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_STP              (UINT32_C(0x40))
-    /*
-     * When this bit is set to '1', the function shall be configured to not
-     * allow the transmission of Link Layer Discovery Protocol (LLDP)
-     * frames. LLDP frames use Ethertype 0x88CC and 48-bit destination
-     * multicast MAC address 01-80-C2-00-00-00 or 01-80-C2-00-00-03 or
-     * 01-80-C2-00-00-0E.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_LLDP             (UINT32_C(0x80))
-    /*
-     * When this bit is set to '1', the function shall be configured to not
-     * allow the transmission of Precision Time Protocol (PTP) v2 frames.
-     * PTP frames use Ethertype 0x88F7 and 48-bit destination multicast MAC
-     * address 01-80-C2-00-00-0E or 01-1B-19-00-00-00.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_PTPV2            (UINT32_C(0x100))
-    /*
-     * Standard TX Ring mode is used for the allocation of TX ring and
-     * underlying scheduling resources that allow bandwidth reservation and
-     * limit settings on the queried function. If set to 1, then standard TX
-     * ring mode is requested to be enabled on the function being
-     * configured. If set to 0, then the standard TX ring mode is requested
-     * to be disabled on the function being configured. In this extended TX
-     * ring resource mode, the minimum and maximum bandwidth settings are
-     * not supported to allow the allocation of TX rings to span multiple
-     * scheduler nodes.
-     */
-    #define HWRM_FUNC_CFG_INPUT_FLAGS_STD_TX_RING_MODE         (UINT32_C(0x200))
-    uint32_t enables;
-    /* This bit must be '1' for the mtu field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_MTU                    (UINT32_C(0x1))
-    /* This bit must be '1' for the mru field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_MRU                    (UINT32_C(0x2))
-    /* This bit must be '1' for the num_rsscos_ctxs field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_RSSCOS_CTXS        (UINT32_C(0x4))
-    /* This bit must be '1' for the num_cmpl_rings field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_CMPL_RINGS         (UINT32_C(0x8))
-    /* This bit must be '1' for the num_tx_rings field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_TX_RINGS           (UINT32_C(0x10))
-    /* This bit must be '1' for the num_rx_rings field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_RX_RINGS           (UINT32_C(0x20))
-    /* This bit must be '1' for the num_l2_ctxs field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_L2_CTXS            (UINT32_C(0x40))
-    /* This bit must be '1' for the num_vnics field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_VNICS              (UINT32_C(0x80))
-    /* This bit must be '1' for the num_stat_ctxs field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_STAT_CTXS          (UINT32_C(0x100))
-    /* This bit must be '1' for the dflt_mac_addr field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_MAC_ADDR          (UINT32_C(0x200))
-    /* This bit must be '1' for the dflt_vlan field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_VLAN              (UINT32_C(0x400))
-    /* This bit must be '1' for the dflt_ip_addr field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_IP_ADDR           (UINT32_C(0x800))
-    /* This bit must be '1' for the min_bw field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_MIN_BW                 (UINT32_C(0x1000))
-    /* This bit must be '1' for the max_bw field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_MAX_BW                 (UINT32_C(0x2000))
-    /* This bit must be '1' for the async_event_cr field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_ASYNC_EVENT_CR         (UINT32_C(0x4000))
-    /*
-     * This bit must be '1' for the vlan_antispoof_mode field to be
-     * configured.
-     */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_VLAN_ANTISPOOF_MODE    (UINT32_C(0x8000))
-    /*
-     * This bit must be '1' for the allowed_vlan_pris field to be
-     * configured.
-     */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_ALLOWED_VLAN_PRIS      (UINT32_C(0x10000))
-    /* This bit must be '1' for the evb_mode field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_EVB_MODE               (UINT32_C(0x20000))
-    /*
-     * This bit must be '1' for the num_mcast_filters field to be
-     * configured.
-     */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_MCAST_FILTERS      (UINT32_C(0x40000))
-    /* This bit must be '1' for the num_hw_ring_grps field to be configured. */
-    #define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_HW_RING_GRPS       (UINT32_C(0x80000))
-    uint16_t mtu;
-    /*
-     * The maximum transmission unit of the function. The HWRM should make
-     * sure that the mtu of the function does not exceed the mtu of the
-     * physical port that this function is associated with. In addition to
-     * configuring mtu per function, it is possible to configure mtu per
-     * transmit ring. By default, the mtu of each transmit ring associated
-     * with a function is equal to the mtu of the function. The HWRM should
-     * make sure that the mtu of each transmit ring that is assigned to a
-     * function has a valid mtu.
-     */
-    uint16_t mru;
-    /*
-     * The maximum receive unit of the function. The HWRM should make sure
-     * that the mru of the function does not exceed the mru of the physical
-     * port that this function is associated with. In addition to
-     * configuring mru per function, it is possible to configure mru per
-     * vnic. By default, the mru of each vnic associated with a function is
-     * equal to the mru of the function. The HWRM should make sure that the
-     * mru of each vnic that is assigned to a function has a valid mru.
-     */
-    uint16_t num_rsscos_ctxs;
-    /* The number of RSS/COS contexts requested for the function. */
-    uint16_t num_cmpl_rings;
-    /*
-     * The number of completion rings requested for the function. This does
-     * not include the rings allocated to any children functions if any.
-     */
-    uint16_t num_tx_rings;
-    /*
-     * The number of transmit rings requested for the function. This does
-     * not include the rings allocated to any children functions if any.
-     */
-    uint16_t num_rx_rings;
-    /*
-     * The number of receive rings requested for the function. This does not
-     * include the rings allocated to any children functions if any.
-     */
-    uint16_t num_l2_ctxs;
-    /* The requested number of L2 contexts for the function. */
-    uint16_t num_vnics;
-    /* The requested number of vnics for the function. */
-    uint16_t num_stat_ctxs;
-    /* The requested number of statistic contexts for the function. */
-    uint16_t num_hw_ring_grps;
-    /*
-     * The number of HW ring groups that should be reserved for this
-     * function.
-     */
-    uint8_t dflt_mac_addr[6];
-    /* The default MAC address for the function being configured. */
-    uint16_t dflt_vlan;
-    /*
-     * The default VLAN for the function being configured. This field's
-     * format is same as 802.1Q Tag's Tag Control Information (TCI) format
-     * that includes both Priority Code Point (PCP) and VLAN Identifier
-     * (VID).
-     */
-    uint32_t dflt_ip_addr[4]; /* big endian */
-    /*
-     * The default IP address for the function being configured. This
-     * address is only used in enabling source property check.
-     */
-    uint32_t min_bw;
-    /*
-     * Minimum BW allocated for this function. The HWRM will translate this
-     * value into byte counter and time interval used for the scheduler
-     * inside the device.
-     */
-    /* Bandwidth value */
-    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_MASK           (UINT32_C(0xfffffff))
-    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_SFT            (UINT32_C(0))
-    /* Reserved */
-    #define HWRM_FUNC_CFG_INPUT_MIN_BW_RSVD                    (UINT32_C(0x10000000))
-    /* bw_value_unit is 3 b */
-    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_MASK      (UINT32_C(0xe0000000))
-    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_SFT       (UINT32_C(29))
-        /* Value is in Mbps */
-        #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_MBPS     (UINT32_C(0))
-        /* Value is in 1/100th of a percentage of total bandwidth. */
-        #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_PERCENT1_100 (UINT32_C(0x1) << 29)
-        /* Invalid unit */
-        #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_INVALID  (UINT32_C(0x7) << 29)
-        #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_LAST    HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_INVALID
-    uint32_t max_bw;
-    /*
-     * Maximum BW allocated for this function. The HWRM will translate this
-     * value into byte counter and time interval used for the scheduler
-     * inside the device.
-     */
-    /* Bandwidth value */
-    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_MASK           (UINT32_C(0xfffffff))
-    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_SFT            (UINT32_C(0))
-    /* Reserved */
-    #define HWRM_FUNC_CFG_INPUT_MAX_BW_RSVD                    (UINT32_C(0x10000000))
-    /* bw_value_unit is 3 b */
-    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_MASK      (UINT32_C(0xe0000000))
-    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_SFT       29
-        /* Value is in Mbps */
-        #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_MBPS     (UINT32_C(0))
-        /* Value is in 1/100th of a percentage of total bandwidth. */
-        #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_PERCENT1_100 (UINT32_C(0x1) << 29)
-        /* Invalid unit */
-        #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_INVALID  (UINT32_C(0x7) << 29)
-        #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_LAST    HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_INVALID
-    uint16_t async_event_cr;
-    /*
-     * ID of the target completion ring for receiving asynchronous event
-     * completions. If this field is not valid, then the HWRM shall use the
-     * default completion ring of the function that is being configured as
-     * the target completion ring for providing any asynchronous event
-     * completions for that function. If this field is valid, then the HWRM
-     * shall use the completion ring identified by this ID as the target
-     * completion ring for providing any asynchronous event completions for
-     * the function that is being configured.
-     */
-    uint8_t vlan_antispoof_mode;
-    /* VLAN Anti-spoofing mode. */
-        /* No VLAN anti-spoofing checks are enabled */
-        #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_NOCHECK   0x0UL
-        /* Validate VLAN against the configured VLAN(s) */
-        #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_VALIDATE_VLAN 0x1UL
-        /* Insert VLAN if it does not exist, otherwise discard */
-        #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_INSERT_IF_VLANDNE 0x2UL
-        /* Insert VLAN if it does not exist, override VLAN if it exists */
-        #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_INSERT_OR_OVERRIDE_VLAN 0x3UL
-    uint8_t allowed_vlan_pris;
-    /*
-     * This bit field defines VLAN PRIs that are allowed on this function.
-     * If nth bit is set, then VLAN PRI n is allowed on this function.
-     */
-    uint8_t evb_mode;
-    /*
-     * The HWRM shall allow a PF driver to change EVB mode for the partition
-     * it belongs to. The HWRM shall not allow a VF driver to change the EVB
-     * mode. The HWRM shall take into account the switching of EVB mode from
-     * one to another and reconfigure hardware resources as appropriately.
-     * The switching from VEB to VEPA mode requires the disabling of the
-     * loopback traffic. Additionally, source knock outs are handled
-     * differently in VEB and VEPA modes.
-     */
-        /* No Edge Virtual Bridging (EVB) */
-        #define HWRM_FUNC_CFG_INPUT_EVB_MODE_NO_EVB               0x0UL
-        /* Virtual Ethernet Bridge (VEB) */
-        #define HWRM_FUNC_CFG_INPUT_EVB_MODE_VEB                  0x1UL
-        /* Virtual Ethernet Port Aggregator (VEPA) */
-        #define HWRM_FUNC_CFG_INPUT_EVB_MODE_VEPA                 0x2UL
-    uint8_t unused_2;
-    uint16_t num_mcast_filters;
-    /*
-     * The number of multicast filters that should be reserved for this
-     * function on the RX side.
-     */
+	uint16_t req_type;
+	/*
+	 * This value indicates what type of request this is. The format for the
+	 * rest of the command is determined by this field.
+	 */
+	uint16_t cmpl_ring;
+	/*
+	 * This value indicates the what completion ring the request will be
+	 * optionally completed on. If the value is -1, then no CR completion
+	 * will be generated. Any other value must be a valid CR ring_id value
+	 * for this function.
+	 */
+	uint16_t seq_id;
+	/* This value indicates the command sequence number. */
+	uint16_t target_id;
+	/*
+	 * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
+	 * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+	 */
+	uint64_t resp_addr;
+	/*
+	 * This is the host address where the response will be written when the
+	 * request is complete. This area must be 16B aligned and must be
+	 * cleared to zero before the request is made.
+	 */
+	uint16_t fid;
+	/*
+	 * Function ID of the function that is being configured. If set to
+	 * 0xFF... (All Fs), then the the configuration is for the requesting
+	 * function.
+	 */
+	uint8_t unused_0;
+	uint8_t unused_1;
+	uint32_t flags;
+	/*
+	 * When this bit is '1', the function is requested to be put in the
+	 * promiscuous mode.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_PROM_MODE                (UINT32_C(0x1))
+	/*
+	 * When this bit is '1', the function is enabled with source MAC address
+	 * check. This is an anti-spoofing check. If this flag is set, then the
+	 * function shall be configured to allow transmission of frames with the
+	 * source MAC address that is configured for this function.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_SRC_MAC_ADDR_CHECK       (UINT32_C(0x2))
+	/*
+	 * When this bit is '1', the function is enabled with source IP address
+	 * check. This is an anti-spoofing check. If this flag is set, then the
+	 * function shall be configured to allow transmission of frames with the
+	 * source IP address that is configured for this function.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_SRC_IP_ADDR_CHECK        (UINT32_C(0x4))
+	/*
+	 * When this bit is set to '1', the function shall be configured with
+	 * VLAN priority match. If the VLAN PRI of a packet originated from this
+	 * function does not match, then the packet shall be discarded.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_VLAN_PRI_MATCH           (UINT32_C(0x8))
+	/*
+	 * When this bit is set to '1', the function shall be configured to
+	 * check for VLAN priority match. If the VLAN PRI of a packet originated
+	 * from this function does not match, then the default VLAN PRI shall be
+	 * used.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_DFLT_PRI_NOMATCH         (UINT32_C(0x10))
+	/*
+	 * When this bit is set to '1', the function shall be configured to not
+	 * allow the transmission of pause frames. PAUSE frames use 48-bit
+	 * destination multicast MAC address 01-80-C2-00-00-01.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_PAUSE            (UINT32_C(0x20))
+	/*
+	 * When this bit is set to '1', the function shall be configured to not
+	 * allow the transmission of Spanning Tree Protocol (STP) frames. STP
+	 * frames use Ethertype 0x0802 and 48-bit destination multicast MAC
+	 * address 01-80-C2-00-00-00 and 01-80-C2-00-00-08 for 802.1D and
+	 * 802.1ad respectively.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_STP              (UINT32_C(0x40))
+	/*
+	 * When this bit is set to '1', the function shall be configured to not
+	 * allow the transmission of Link Layer Discovery Protocol (LLDP)
+	 * frames. LLDP frames use Ethertype 0x88CC and 48-bit destination
+	 * multicast MAC address 01-80-C2-00-00-00 or 01-80-C2-00-00-03 or
+	 * 01-80-C2-00-00-0E.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_LLDP             (UINT32_C(0x80))
+	/*
+	 * When this bit is set to '1', the function shall be configured to not
+	 * allow the transmission of Precision Time Protocol (PTP) v2 frames.
+	 * PTP frames use Ethertype 0x88F7 and 48-bit destination multicast MAC
+	 * address 01-80-C2-00-00-0E or 01-1B-19-00-00-00.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_DISABLE_PTPV2            (UINT32_C(0x100))
+	/*
+	 * Standard TX Ring mode is used for the allocation of TX ring and
+	 * underlying scheduling resources that allow bandwidth reservation and
+	 * limit settings on the queried function. If set to 1, then standard TX
+	 * ring mode is requested to be enabled on the function being
+	 * configured. If set to 0, then the standard TX ring mode is requested
+	 * to be disabled on the function being configured. In this extended TX
+	 * ring resource mode, the minimum and maximum bandwidth settings are
+	 * not supported to allow the allocation of TX rings to span multiple
+	 * scheduler nodes.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_FLAGS_STD_TX_RING_MODE         (UINT32_C(0x200))
+	uint32_t enables;
+	/* This bit must be '1' for the mtu field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_MTU                    (UINT32_C(0x1))
+	/* This bit must be '1' for the mru field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_MRU                    (UINT32_C(0x2))
+	/* This bit must be '1' for the num_rsscos_ctxs field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_RSSCOS_CTXS        (UINT32_C(0x4))
+	/* This bit must be '1' for the num_cmpl_rings field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_CMPL_RINGS         (UINT32_C(0x8))
+	/* This bit must be '1' for the num_tx_rings field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_TX_RINGS           (UINT32_C(0x10))
+	/* This bit must be '1' for the num_rx_rings field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_RX_RINGS           (UINT32_C(0x20))
+	/* This bit must be '1' for the num_l2_ctxs field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_L2_CTXS            (UINT32_C(0x40))
+	/* This bit must be '1' for the num_vnics field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_VNICS              (UINT32_C(0x80))
+	/* This bit must be '1' for the num_stat_ctxs field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_STAT_CTXS          (UINT32_C(0x100))
+	/* This bit must be '1' for the dflt_mac_addr field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_MAC_ADDR          (UINT32_C(0x200))
+	/* This bit must be '1' for the dflt_vlan field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_VLAN              (UINT32_C(0x400))
+	/* This bit must be '1' for the dflt_ip_addr field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_DFLT_IP_ADDR           (UINT32_C(0x800))
+	/* This bit must be '1' for the min_bw field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_MIN_BW                 (UINT32_C(0x1000))
+	/* This bit must be '1' for the max_bw field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_MAX_BW                 (UINT32_C(0x2000))
+	/* This bit must be '1' for the async_event_cr field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_ASYNC_EVENT_CR         (UINT32_C(0x4000))
+	/*
+	 * This bit must be '1' for the vlan_antispoof_mode field to be
+	 * configured.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_VLAN_ANTISPOOF_MODE    (UINT32_C(0x8000))
+	/*
+	 * This bit must be '1' for the allowed_vlan_pris field to be
+	 * configured.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_ALLOWED_VLAN_PRIS      (UINT32_C(0x10000))
+	/* This bit must be '1' for the evb_mode field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_EVB_MODE               (UINT32_C(0x20000))
+	/*
+	 * This bit must be '1' for the num_mcast_filters field to be
+	 * configured.
+	 */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_MCAST_FILTERS      (UINT32_C(0x40000))
+	/* This bit must be '1' for the num_hw_ring_grps field to be configured. */
+	#define HWRM_FUNC_CFG_INPUT_ENABLES_NUM_HW_RING_GRPS       (UINT32_C(0x80000))
+	uint16_t mtu;
+	/*
+	 * The maximum transmission unit of the function. The HWRM should make
+	 * sure that the mtu of the function does not exceed the mtu of the
+	 * physical port that this function is associated with. In addition to
+	 * configuring mtu per function, it is possible to configure mtu per
+	 * transmit ring. By default, the mtu of each transmit ring associated
+	 * with a function is equal to the mtu of the function. The HWRM should
+	 * make sure that the mtu of each transmit ring that is assigned to a
+	 * function has a valid mtu.
+	 */
+	uint16_t mru;
+	/*
+	 * The maximum receive unit of the function. The HWRM should make sure
+	 * that the mru of the function does not exceed the mru of the physical
+	 * port that this function is associated with. In addition to
+	 * configuring mru per function, it is possible to configure mru per
+	 * vnic. By default, the mru of each vnic associated with a function is
+	 * equal to the mru of the function. The HWRM should make sure that the
+	 * mru of each vnic that is assigned to a function has a valid mru.
+	 */
+	uint16_t num_rsscos_ctxs;
+	/* The number of RSS/COS contexts requested for the function. */
+	uint16_t num_cmpl_rings;
+	/*
+	 * The number of completion rings requested for the function. This does
+	 * not include the rings allocated to any children functions if any.
+	 */
+	uint16_t num_tx_rings;
+	/*
+	 * The number of transmit rings requested for the function. This does
+	 * not include the rings allocated to any children functions if any.
+	 */
+	uint16_t num_rx_rings;
+	/*
+	 * The number of receive rings requested for the function. This does not
+	 * include the rings allocated to any children functions if any.
+	 */
+	uint16_t num_l2_ctxs;
+	/* The requested number of L2 contexts for the function. */
+	uint16_t num_vnics;
+	/* The requested number of vnics for the function. */
+	uint16_t num_stat_ctxs;
+	/* The requested number of statistic contexts for the function. */
+	uint16_t num_hw_ring_grps;
+	/*
+	 * The number of HW ring groups that should be reserved for this
+	 * function.
+	 */
+	uint8_t dflt_mac_addr[6];
+	/* The default MAC address for the function being configured. */
+	uint16_t dflt_vlan;
+	/*
+	 * The default VLAN for the function being configured. This field's
+	 * format is same as 802.1Q Tag's Tag Control Information (TCI) format
+	 * that includes both Priority Code Point (PCP) and VLAN Identifier
+	 * (VID).
+	 */
+	uint32_t dflt_ip_addr[4]; /* big endian */
+	/*
+	 * The default IP address for the function being configured. This
+	 * address is only used in enabling source property check.
+	 */
+	uint32_t min_bw;
+	/*
+	 * Minimum BW allocated for this function. The HWRM will translate this
+	 * value into byte counter and time interval used for the scheduler
+	 * inside the device.
+	 */
+	/* Bandwidth value */
+	#define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_MASK           (UINT32_C(0xfffffff))
+	#define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_SFT            (UINT32_C(0))
+	/* Reserved */
+	#define HWRM_FUNC_CFG_INPUT_MIN_BW_RSVD                    (UINT32_C(0x10000000))
+	/* bw_value_unit is 3 b */
+	#define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_MASK      (UINT32_C(0xe0000000))
+	#define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_SFT       (UINT32_C(29))
+	    /* Value is in Mbps */
+	    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_MBPS     (UINT32_C(0))
+	    /* Value is in 1/100th of a percentage of total bandwidth. */
+	    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_PERCENT1_100 (UINT32_C(0x1) << 29)
+	    /* Invalid unit */
+	    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_INVALID  (UINT32_C(0x7) << 29)
+	    #define HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_LAST    HWRM_FUNC_CFG_INPUT_MIN_BW_BW_VALUE_UNIT_INVALID
+	uint32_t max_bw;
+	/*
+	 * Maximum BW allocated for this function. The HWRM will translate this
+	 * value into byte counter and time interval used for the scheduler
+	 * inside the device.
+	 */
+	/* Bandwidth value */
+	#define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_MASK           (UINT32_C(0xfffffff))
+	#define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_SFT            (UINT32_C(0))
+	/* Reserved */
+	#define HWRM_FUNC_CFG_INPUT_MAX_BW_RSVD                    (UINT32_C(0x10000000))
+	/* bw_value_unit is 3 b */
+	#define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_MASK      (UINT32_C(0xe0000000))
+	#define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_SFT       29
+	    /* Value is in Mbps */
+	    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_MBPS     (UINT32_C(0))
+	    /* Value is in 1/100th of a percentage of total bandwidth. */
+	    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_PERCENT1_100 (UINT32_C(0x1) << 29)
+	    /* Invalid unit */
+	    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_INVALID  (UINT32_C(0x7) << 29)
+	    #define HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_LAST    HWRM_FUNC_CFG_INPUT_MAX_BW_BW_VALUE_UNIT_INVALID
+	uint16_t async_event_cr;
+	/*
+	 * ID of the target completion ring for receiving asynchronous event
+	 * completions. If this field is not valid, then the HWRM shall use the
+	 * default completion ring of the function that is being configured as
+	 * the target completion ring for providing any asynchronous event
+	 * completions for that function. If this field is valid, then the HWRM
+	 * shall use the completion ring identified by this ID as the target
+	 * completion ring for providing any asynchronous event completions for
+	 * the function that is being configured.
+	 */
+	uint8_t vlan_antispoof_mode;
+	/* VLAN Anti-spoofing mode. */
+	    /* No VLAN anti-spoofing checks are enabled */
+	    #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_NOCHECK   0x0UL
+	    /* Validate VLAN against the configured VLAN(s) */
+	    #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_VALIDATE_VLAN 0x1UL
+	    /* Insert VLAN if it does not exist, otherwise discard */
+	    #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_INSERT_IF_VLANDNE 0x2UL
+	    /* Insert VLAN if it does not exist, override VLAN if it exists */
+	    #define HWRM_FUNC_CFG_INPUT_VLAN_ANTISPOOF_MODE_INSERT_OR_OVERRIDE_VLAN 0x3UL
+	uint8_t allowed_vlan_pris;
+	/*
+	 * This bit field defines VLAN PRIs that are allowed on this function.
+	 * If nth bit is set, then VLAN PRI n is allowed on this function.
+	 */
+	uint8_t evb_mode;
+	/*
+	 * The HWRM shall allow a PF driver to change EVB mode for the partition
+	 * it belongs to. The HWRM shall not allow a VF driver to change the EVB
+	 * mode. The HWRM shall take into account the switching of EVB mode from
+	 * one to another and reconfigure hardware resources as appropriately.
+	 * The switching from VEB to VEPA mode requires the disabling of the
+	 * loopback traffic. Additionally, source knock outs are handled
+	 * differently in VEB and VEPA modes.
+	 */
+	    /* No Edge Virtual Bridging (EVB) */
+	    #define HWRM_FUNC_CFG_INPUT_EVB_MODE_NO_EVB               0x0UL
+	    /* Virtual Ethernet Bridge (VEB) */
+	    #define HWRM_FUNC_CFG_INPUT_EVB_MODE_VEB                  0x1UL
+	    /* Virtual Ethernet Port Aggregator (VEPA) */
+	    #define HWRM_FUNC_CFG_INPUT_EVB_MODE_VEPA                 0x2UL
+	uint8_t unused_2;
+	uint16_t num_mcast_filters;
+	/*
+	 * The number of multicast filters that should be reserved for this
+	 * function on the RX side.
+	 */
 } __attribute__((packed));
 
 /* Output (16 bytes) */
 struct hwrm_func_cfg_output {
-    uint16_t error_code;
-    /*
-     * Pass/Fail or error type Note: receiver to verify the in parameters,
-     * and fail the call with an error when appropriate
-     */
-    uint16_t req_type;
-    /* This field returns the type of original request. */
-    uint16_t seq_id;
-    /* This field provides original sequence number of the command. */
-    uint16_t resp_len;
-    /*
-     * This field is the length of the response in bytes. The last byte of
-     * the response is a valid flag that will read as '1' when the command
-     * has been completely written to memory.
-     */
-    uint32_t unused_0;
-    uint8_t unused_1;
-    uint8_t unused_2;
-    uint8_t unused_3;
-    uint8_t valid;
-    /*
-     * This field is used in Output records to indicate that the output is
-     * completely written to RAM. This field should be read as '1' to
-     * indicate that the output has been completely written. When writing a
-     * command completion or response to an internal processor, the order of
-     * writes has to be such that this field is written last.
-     */
+	uint16_t error_code;
+	/*
+	 * Pass/Fail or error type Note: receiver to verify the in parameters,
+	 * and fail the call with an error when appropriate
+	 */
+	uint16_t req_type;
+	/* This field returns the type of original request. */
+	uint16_t seq_id;
+	/* This field provides original sequence number of the command. */
+	uint16_t resp_len;
+	/*
+	 * This field is the length of the response in bytes. The last byte of
+	 * the response is a valid flag that will read as '1' when the command
+	 * has been completely written to memory.
+	 */
+	uint32_t unused_0;
+	uint8_t unused_1;
+	uint8_t unused_2;
+	uint8_t unused_3;
+	uint8_t valid;
+	/*
+	 * This field is used in Output records to indicate that the output is
+	 * completely written to RAM. This field should be read as '1' to
+	 * indicate that the output has been completely written. When writing a
+	 * command completion or response to an internal processor, the order of
+	 * writes has to be such that this field is written last.
+	 */
 } __attribute__((packed));
+
 /* hwrm_func_drv_rgtr */
 /*
  * Description: This command is used by the function driver to register its
@@ -2793,6 +2875,117 @@ struct hwrm_func_drv_rgtr_output {
 	 * written. When writing a command completion or response to an
 	 * internal processor, the order of writes has to be such that
 	 * this field is written last.
+	 */
+} __attribute__((packed));
+
+/* hwrm_func_buf_rgtr */
+/*
+ * Description: This command is used by the PF driver to register buffers used
+ * in the PF-VF communication with the HWRM. The PF driver uses this command to
+ * register buffers for each PF-VF channel. A parent PF may issue this command
+ * per child VF. If VF ID is not valid, then this command is used to register
+ * buffers for all children VFs of the PF.
+ */
+/* Input (128 bytes) */
+struct hwrm_func_buf_rgtr_input {
+	uint16_t req_type;
+	/*
+	 * This value indicates what type of request this is. The format for the
+	 * rest of the command is determined by this field.
+	 */
+	uint16_t cmpl_ring;
+	/*
+	 * This value indicates the what completion ring the request will be
+	 * optionally completed on. If the value is -1, then no CR completion
+	 * will be generated. Any other value must be a valid CR ring_id value
+	 * for this function.
+	 */
+	uint16_t seq_id;
+	/* This value indicates the command sequence number. */
+	uint16_t target_id;
+	/*
+	 * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
+	 * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+	 */
+	uint64_t resp_addr;
+	/*
+	 * This is the host address where the response will be written when the
+	 * request is complete. This area must be 16B aligned and must be
+	 * cleared to zero before the request is made.
+	 */
+	uint32_t enables;
+	/* This bit must be '1' for the vf_id field to be configured. */
+	#define HWRM_FUNC_BUF_RGTR_INPUT_ENABLES_VF_ID             (UINT32_C(0x1))
+	/* This bit must be '1' for the err_buf_addr field to be configured. */
+	#define HWRM_FUNC_BUF_RGTR_INPUT_ENABLES_ERR_BUF_ADDR      (UINT32_C(0x2))
+	uint16_t vf_id;
+	/*
+	 * This value is used to identify a Virtual Function (VF). The scope of
+	 * VF ID is local within a PF.
+	 */
+	uint16_t req_buf_num_pages;
+	/* This field represents the number of pages used for request buffer(s). */
+	uint16_t req_buf_page_size;
+	/* This field represents the page size used for request buffer(s). */
+	    /* 16 bytes */
+	    #define HWRM_FUNC_BUF_RGTR_INPUT_REQ_BUF_PAGE_SIZE_16B    (UINT32_C(0x4))
+	    /* 4 Kbytes */
+	    #define HWRM_FUNC_BUF_RGTR_INPUT_REQ_BUF_PAGE_SIZE_4K     (UINT32_C(0xc))
+	    /* 8 Kbytes */
+	    #define HWRM_FUNC_BUF_RGTR_INPUT_REQ_BUF_PAGE_SIZE_8K     (UINT32_C(0xd))
+	    /* 64 Kbytes */
+	    #define HWRM_FUNC_BUF_RGTR_INPUT_REQ_BUF_PAGE_SIZE_64K    (UINT32_C(0x10)
+	    /* 2 Mbytes */
+	    #define HWRM_FUNC_BUF_RGTR_INPUT_REQ_BUF_PAGE_SIZE_2M     (UINT32_C(0x15)
+	    /* 4 Mbytes */
+	    #define HWRM_FUNC_BUF_RGTR_INPUT_REQ_BUF_PAGE_SIZE_4M     (UINT32_C(0x16)
+	    /* 1 Gbytes */
+	    #define HWRM_FUNC_BUF_RGTR_INPUT_REQ_BUF_PAGE_SIZE_1G     (UINT32_C(0x1e)
+	uint16_t req_buf_len;
+	/* The length of the request buffer per VF in bytes. */
+	uint16_t resp_buf_len;
+	/* The length of the response buffer in bytes. */
+	uint8_t unused_0;
+	uint8_t unused_1;
+	/* This field represents the page addresses. */
+	uint64_t req_buf_page_addr[10];
+	uint64_t error_buf_addr;
+	/*
+	 * This field is used to receive the error reporting from the chipset.
+	 * Only applicable for PFs.
+	 */
+	uint64_t resp_buf_addr;
+	/* This field is used to receive the response forwarded by the HWRM. */
+} __attribute__((packed));
+
+/* Output (16 bytes) */
+struct hwrm_func_buf_rgtr_output {
+	uint16_t error_code;
+	/*
+	 * Pass/Fail or error type Note: receiver to verify the in parameters,
+	 * and fail the call with an error when appropriate
+	 */
+	uint16_t req_type;
+	/* This field returns the type of original request. */
+	uint16_t seq_id;
+	/* This field provides original sequence number of the command. */
+	uint16_t resp_len;
+	/*
+	 * This field is the length of the response in bytes. The last byte of
+	 * the response is a valid flag that will read as '1' when the command
+	 * has been completely written to memory.
+	 */
+	uint32_t unused_0;
+	uint8_t unused_1;
+	uint8_t unused_2;
+	uint8_t unused_3;
+	uint8_t valid;
+	/*
+	 * This field is used in Output records to indicate that the output is
+	 * completely written to RAM. This field should be read as '1' to
+	 * indicate that the output has been completely written. When writing a
+	 * command completion or response to an internal processor, the order of
+	 * writes has to be such that this field is written last.
 	 */
 } __attribute__((packed));
 
@@ -6418,6 +6611,89 @@ struct hwrm_exec_fwd_resp_output {
 	 * internal processor, the order of writes has to be such that
 	 * this field is written last.
 	 */
+} __attribute__((packed));
+
+/* hwrm_reject_fwd_resp */
+/*
+ * Description: This command is used to send an encapsulated request to the
+ * HWRM. This command instructs the HWRM to reject the request and forward the
+ * error response of the encapsulated request to the location specified in the
+ * original request that is encapsulated. The target id of this command shall be
+ * set to 0xFFFF (HWRM). The response location in this command shall be used to
+ * acknowledge the receipt of the encapsulated request and forwarding of the
+ * response.
+ */
+/* Input (128 bytes) */
+struct hwrm_reject_fwd_resp_input {
+    uint16_t req_type;
+    /*
+     * This value indicates what type of request this is. The format for the
+     * rest of the command is determined by this field.
+     */
+    uint16_t cmpl_ring;
+    /*
+     * This value indicates the what completion ring the request will be
+     * optionally completed on. If the value is -1, then no CR completion
+     * will be generated. Any other value must be a valid CR ring_id value
+     * for this function.
+     */
+    uint16_t seq_id;
+    /* This value indicates the command sequence number. */
+    uint16_t target_id;
+    /*
+     * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
+     * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+     */
+    uint64_t resp_addr;
+    /*
+     * This is the host address where the response will be written when the
+     * request is complete. This area must be 16B aligned and must be
+     * cleared to zero before the request is made.
+     */
+    uint32_t encap_request[26];
+    /*
+     * This is an encapsulated request. This request should be rejected by
+     * the HWRM and the error response should be provided in the response
+     * buffer inside the encapsulated request.
+     */
+    uint16_t encap_resp_target_id;
+    /*
+     * This value indicates the target id of the response to the
+     * encapsulated request. 0x0 - 0xFFF8 - Used for function ids 0xFFF8 -
+     * 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+     */
+    uint16_t unused_0[3];
+} __attribute__((packed));
+
+/* Output (16 bytes) */
+struct hwrm_reject_fwd_resp_output {
+    uint16_t error_code;
+    /*
+     * Pass/Fail or error type Note: receiver to verify the in parameters,
+     * and fail the call with an error when appropriate
+     */
+    uint16_t req_type;
+    /* This field returns the type of original request. */
+    uint16_t seq_id;
+    /* This field provides original sequence number of the command. */
+    uint16_t resp_len;
+    /*
+     * This field is the length of the response in bytes. The last byte of
+     * the response is a valid flag that will read as '1' when the command
+     * has been completely written to memory.
+     */
+    uint32_t unused_0;
+    uint8_t unused_1;
+    uint8_t unused_2;
+    uint8_t unused_3;
+    uint8_t valid;
+    /*
+     * This field is used in Output records to indicate that the output is
+     * completely written to RAM. This field should be read as '1' to
+     * indicate that the output has been completely written. When writing a
+     * command completion or response to an internal processor, the order of
+     * writes has to be such that this field is written last.
+     */
 } __attribute__((packed));
 
 #endif

--- a/drivers/net/bnxt/hsi_struct_def_dpdk.h
+++ b/drivers/net/bnxt/hsi_struct_def_dpdk.h
@@ -91,6 +91,7 @@ struct ctx_hw_stats64 {
 #define HWRM_FUNC_QCFG			(UINT32_C(0x16))
 #define HWRM_FUNC_CFG			(UINT32_C(0x17))
 #define HWRM_FUNC_DRV_UNRGTR		(UINT32_C(0x1a))
+#define HWRM_FUNC_VF_VNIC_IDS_QUERY	(UINT32_C(0x1c))
 #define HWRM_FUNC_DRV_RGTR		(UINT32_C(0x1d))
 #define HWRM_FUNC_BUF_RGTR		(UINT32_C(0x1f))
 #define HWRM_PORT_PHY_CFG		(UINT32_C(0x20))
@@ -3062,6 +3063,82 @@ struct hwrm_func_drv_unrgtr_output {
 	 * internal processor, the order of writes has to be such that
 	 * this field is written last.
 	 */
+} __attribute__((packed));
+
+/* hwrm_func_vf_vnic_ids_query */
+/* Description: This command is used to query vf vnic ids. */
+/* Input (32 bytes) */
+struct hwrm_func_vf_vnic_ids_query_input
+{
+    uint16_t req_type;
+    /*
+     * This value indicates what type of request this is. The format for the
+     * rest of the command is determined by this field.
+     */
+    uint16_t cmpl_ring;
+    /*
+     * This value indicates the what completion ring the request will be
+     * optionally completed on. If the value is -1, then no CR completion
+     * will be generated. Any other value must be a valid CR ring_id value
+     * for this function.
+     */
+    uint16_t seq_id;
+    /* This value indicates the command sequence number. */
+    uint16_t target_id;
+    /*
+     * Target ID of this command. 0x0 - 0xFFF8 - Used for function ids
+     * 0xFFF8 - 0xFFFE - Reserved for internal processors 0xFFFF - HWRM
+     */
+    uint64_t resp_addr;
+    /*
+     * This is the host address where the response will be written when the
+     * request is complete. This area must be 16B aligned and must be
+     * cleared to zero before the request is made.
+     */
+    uint16_t vf_id;
+    /*
+     * This value is used to identify a Virtual Function (VF). The scope of
+     * VF ID is local within a PF.
+     */
+    uint8_t unused_0;
+    uint8_t unused_1;
+    uint32_t max_vnic_id_cnt;
+    /* Max number of vnic ids in vnic id table */
+    uint32_t vnic_id_tbl_addr[2];
+    /* This is the address for VF VNIC ID table */
+} __attribute__((packed));
+
+/* Output (16 bytes) */
+struct hwrm_func_vf_vnic_ids_query_output
+{
+	uint16_t error_code;
+    /*
+     * Pass/Fail or error type Note: receiver to verify the in parameters,
+     * and fail the call with an error when appropriate
+     */
+    uint16_t req_type;
+    /* This field returns the type of original request. */
+    uint16_t seq_id;
+    /* This field provides original sequence number of the command. */
+    uint16_t resp_len;
+    /*
+     * This field is the length of the response in bytes. The last byte of
+     * the response is a valid flag that will read as '1' when the command
+     * has been completely written to memory.
+     */
+    uint32_t vnic_id_cnt;
+    /* Actual number of vnic ids Each VNIC ID is written as a 32-bit number. */
+    uint8_t unused_0;
+    uint8_t unused_1;
+    uint8_t unused_2;
+    uint8_t valid;
+    /*
+     * This field is used in Output records to indicate that the output is
+     * completely written to RAM. This field should be read as '1' to
+     * indicate that the output has been completely written. When writing a
+     * command completion or response to an internal processor, the order of
+     * writes has to be such that this field is written last.
+     */
 } __attribute__((packed));
 
 /* hwrm_port_phy_cfg */

--- a/drivers/net/bnxt/hsi_struct_def_dpdk.h
+++ b/drivers/net/bnxt/hsi_struct_def_dpdk.h
@@ -3068,8 +3068,7 @@ struct hwrm_func_drv_unrgtr_output {
 /* hwrm_func_vf_vnic_ids_query */
 /* Description: This command is used to query vf vnic ids. */
 /* Input (32 bytes) */
-struct hwrm_func_vf_vnic_ids_query_input
-{
+struct hwrm_func_vf_vnic_ids_query_input {
     uint16_t req_type;
     /*
      * This value indicates what type of request this is. The format for the
@@ -3104,13 +3103,12 @@ struct hwrm_func_vf_vnic_ids_query_input
     uint8_t unused_1;
     uint32_t max_vnic_id_cnt;
     /* Max number of vnic ids in vnic id table */
-    uint32_t vnic_id_tbl_addr[2];
+    uint64_t vnic_id_tbl_addr;
     /* This is the address for VF VNIC ID table */
 } __attribute__((packed));
 
 /* Output (16 bytes) */
-struct hwrm_func_vf_vnic_ids_query_output
-{
+struct hwrm_func_vf_vnic_ids_query_output {
 	uint16_t error_code;
     /*
      * Pass/Fail or error type Note: receiver to verify the in parameters,

--- a/drivers/net/bnxt/rte_pmd_bnxt.h
+++ b/drivers/net/bnxt/rte_pmd_bnxt.h
@@ -52,4 +52,20 @@
  */
 int rte_pmd_bnxt_set_tx_loopback(uint8_t port, uint8_t on);
 
+/**
+ * set all queues drop enable bit
+ *
+ * @param port
+ *    The port identifier of the Ethernet device.
+ * @param on
+ *    1 - set the queue drop enable bit for all pools.
+ *    0 - reset the queue drop enable bit for all pools.
+ *
+ * @return
+ *   - (0) if successful.
+ *   - (-ENODEV) if *port* invalid.
+ *   - (-EINVAL) if bad parameter.
+ */
+int rte_pmd_bnxt_set_all_queues_drop_en(uint8_t port, uint8_t on);
+
 #endif /* _PMD_BNXT_H_ */

--- a/drivers/net/bnxt/rte_pmd_bnxt_version.map
+++ b/drivers/net/bnxt/rte_pmd_bnxt_version.map
@@ -7,4 +7,5 @@ DPDK_17.02 {
 	global:
 
 	rte_pmd_bnxt_set_tx_loopback;
+	rte_pmd_bnxt_set_all_queues_drop_en;
 };


### PR DESCRIPTION
1. Add bd_stall attribute to bnxt_vnic_info, reuse bnxt_hwrm_vnic_cfg() to configure bd_stall
2. It looks that bd_stall doesn't take effect from test.
3. Plan to introduce HWRM_VNIC_**Q**CFG for VNIC to retrieve VF's vnic info, then issue HWRM_VNIC_CFG , TBD.